### PR TITLE
Add possibility to make requests on staging

### DIFF
--- a/lib/seeuletter/resources/resource_base.rb
+++ b/lib/seeuletter/resources/resource_base.rb
@@ -93,7 +93,7 @@ module Seeuletter
       end
 
       def base_url
-        "https://#{config[:api_key]}:@api.seeuletter.com"
+        "https://#{config[:api_key]}:@api#{@config[:staging] ? '-staging.mysendingbox.fr' : '.seeuletter.com'}"
       end
 
       def endpoint_url


### PR DESCRIPTION
* Add possibility to make requests on Seeuletter staging environment (needed in order to test features not currently available in production API). Client must be initialized using `staging: true` parameter, example :
```ruby
Seeuletter::Client.new(api_key: <API_KEY>, staging: true)
```
* Did not add this option in documentation since [README file](https://github.com/seeuletter/seeuletter-ruby?tab=readme-ov-file#usage) indicates that "_For optional parameters and other details, refer to the docs [here](https://docs.seeuletter.com/?ruby#)_"